### PR TITLE
hide atlas logs

### DIFF
--- a/charts/zesty/templates/deployment.yaml
+++ b/charts/zesty/templates/deployment.yaml
@@ -37,7 +37,7 @@ spec:
           volumeMounts:
             - mountPath: {{ .Values.persistence.mountPath }}
               name: {{ .Values.persistence.volumeName }}
-          args: ["schema", "apply", "--url", "sqlite://{{ .Values.persistence.mountPath}}/zesty.db", "--dev-url", "sqlite://:memory:", "--to",  "file:///bin/pkg/db/schema.sql", "--auto-approve"]
+          args: ["schema", "apply", "--url", "sqlite://{{ .Values.persistence.mountPath}}/zesty.db", "--dev-url", "sqlite://:memory:", "--to",  "file:///bin/pkg/db/schema.sql", "--auto-approve", "--format", "json"]
       containers:
         - image: "{{ .Values.image.repository }}:{{ include "zesty-k8s.version" . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}


### PR DESCRIPTION
The --format json flag will suppress human-readable logs and only print JSON errors if something goes wrong.